### PR TITLE
Implement Smart Rename for Lookups and Formatters

### DIFF
--- a/Controls/LookupEditorControl.cs
+++ b/Controls/LookupEditorControl.cs
@@ -81,6 +81,8 @@ namespace RARPEditor.Controls
         {
             if (_currentLookup != null && _originalName != _currentLookup.Name)
             {
+                string newName = nameTextBox.Text;
+                RefactorMacroReferences(_originalName, newName);
                 _dataChangedAction?.Invoke();
                 _originalName = _currentLookup.Name;
             }
@@ -92,6 +94,29 @@ namespace RARPEditor.Controls
             {
                 _dataChangedAction?.Invoke();
                 _originalDefault = _currentLookup.Default ?? "";
+            }
+        }
+
+        private void RefactorMacroReferences(string oldName, string newName)
+        {
+            if (_currentScript == null || string.IsNullOrEmpty(oldName) || oldName == newName) return;
+
+            int updateCount = 0;
+            foreach (var displayString in _currentScript.DisplayStrings)
+            {
+                foreach (var part in displayString.Parts)
+                {
+                    if (part.IsMacro && part.Text == oldName)
+                    {
+                        part.Text = newName;
+                        updateCount++;
+                    }
+                }
+            }
+
+            if (updateCount > 0)
+            {
+                StatusUpdateRequested?.Invoke(this, $"Smart Rename: Updated {updateCount} reference(s) from '{oldName}' to '{newName}'.");
             }
         }
 

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -236,6 +236,30 @@ namespace RARPEditor.Forms
             }
         }
 
+        private void RefactorMacroReferences(string oldName, string newName)
+        {
+            if (string.IsNullOrEmpty(oldName) || oldName == newName) return;
+
+            bool changed = false;
+            foreach (var displayString in _currentScript.DisplayStrings)
+            {
+                foreach (var part in displayString.Parts)
+                {
+                    if (part.IsMacro && part.Text == oldName)
+                    {
+                        part.Text = newName;
+                        changed = true;
+                    }
+                }
+            }
+
+            if (changed)
+            {
+                UpdateStatus($"Refactored references from '{oldName}' to '{newName}'.");
+                PopulateProjectExplorer();
+            }
+        }
+
         #region Undo / Redo
 
         private void ApplyState(RichPresenceScript state)


### PR DESCRIPTION
Now, when a user renames a Lookup or a Formatter, the application automatically scans all Display Strings and updates any macro references that match the old name. This prevents the Display Logic from breaking and saves the user from manual updates.